### PR TITLE
Non-hades bones grab a fresh inventory ref avoiding nil

### DIFF
--- a/player/bones.lua
+++ b/player/bones.lua
@@ -70,6 +70,7 @@ else
 		local meta = minetest.get_meta(pos)
 		if meta:get_inventory():is_empty("main") then
       local drops = minetest.get_node_drops(bones_node_name, nil)
+      local player_inv = player:get_inventory()
       for _,drop_item in pairs(drops) do
         if player_inv:room_for_item("main", ItemStack(drop_item)) then
           player_inv:add_item("main", ItemStack(drop_item))


### PR DESCRIPTION
Fixes a nil from an undefined reference to player_inv when an admin with protection_bypass picks up the bones of someone else.